### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/gustavoggodinho/f6e34850-4030-4fdd-95b6-8f87ef93218b/c3de1c9f-9ed8-4ba9-8b91-d5a826b19271/_apis/work/boardbadge/9d2d6802-48ce-41c7-8696-1deec0664b06)](https://dev.azure.com/gustavoggodinho/f6e34850-4030-4fdd-95b6-8f87ef93218b/_boards/board/t/c3de1c9f-9ed8-4ba9-8b91-d5a826b19271/Microsoft.RequirementCategory)
 # SQLLOADERArqControlBat
 Monta arquivo bat para o programa SQLLOADER 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1228](https://dev.azure.com/gustavoggodinho/f6e34850-4030-4fdd-95b6-8f87ef93218b/_workitems/edit/1228). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.